### PR TITLE
feat: 이벤트 상품 추가 시 Product Service와 Feign Client 통신을 통해 상품 정보 가져오는 로직 추가

### DIFF
--- a/event-service/build.gradle
+++ b/event-service/build.gradle
@@ -42,6 +42,10 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
+    // feign client
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 dependencyManagement {

--- a/event-service/src/main/java/com/musinsam/eventservice/EventServiceApplication.java
+++ b/event-service/src/main/java/com/musinsam/eventservice/EventServiceApplication.java
@@ -2,7 +2,11 @@ package com.musinsam.eventservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
+@EnableDiscoveryClient
 @SpringBootApplication
 public class EventServiceApplication {
 

--- a/event-service/src/main/java/com/musinsam/eventservice/application/dto/request/ReqEventPostByEventIdDtoApiV1.java
+++ b/event-service/src/main/java/com/musinsam/eventservice/application/dto/request/ReqEventPostByEventIdDtoApiV1.java
@@ -37,9 +37,10 @@ public class ReqEventPostByEventIdDtoApiV1 {
     private Integer discountRate;
 
 
-    public EventProductEntity toEntity(EventEntity eventEntity) {
+    public EventProductEntity toEntity(EventEntity eventEntity, String productName) {
       return EventProductEntity.builder()
           .productId(productId)
+          .productName(productName)
           .discountRate(discountRate)
           .soldQuantity(0)
           .event(eventEntity)

--- a/event-service/src/main/java/com/musinsam/eventservice/application/dto/response/ResEventGetByEventIdDtoApiV1.java
+++ b/event-service/src/main/java/com/musinsam/eventservice/application/dto/response/ResEventGetByEventIdDtoApiV1.java
@@ -70,6 +70,7 @@ public class ResEventGetByEventIdDtoApiV1 {
       public static EventProduct from(EventProductEntity eventProductEntity) {
         return EventProduct.builder()
             .productId(eventProductEntity.getProductId())
+            .productName(eventProductEntity.getProductName())
             .discountRate(eventProductEntity.getDiscountRate())
             .soldQuantity(eventProductEntity.getSoldQuantity())
             .build();

--- a/event-service/src/main/java/com/musinsam/eventservice/application/dto/response/ResEventGetProductByEventIdDtoApiV1.java
+++ b/event-service/src/main/java/com/musinsam/eventservice/application/dto/response/ResEventGetProductByEventIdDtoApiV1.java
@@ -52,6 +52,7 @@ public class ResEventGetProductByEventIdDtoApiV1 {
       private UUID id;
       private UUID eventId;
       private UUID productId;
+      private String productName;
       private Integer discountRate;
       private Integer soldQuantity;
       private EventStatus status;
@@ -68,6 +69,7 @@ public class ResEventGetProductByEventIdDtoApiV1 {
             .id(eventProductEntity.getId())
             .eventId(eventProductEntity.getEvent().getId())
             .productId(eventProductEntity.getProductId())
+            .productName(eventProductEntity.getProductName())
             .discountRate(eventProductEntity.getDiscountRate())
             .soldQuantity(eventProductEntity.getSoldQuantity())
             .status(eventProductEntity.getEvent().getStatus())

--- a/event-service/src/main/java/com/musinsam/eventservice/application/integration/ProductClient.java
+++ b/event-service/src/main/java/com/musinsam/eventservice/application/integration/ProductClient.java
@@ -1,0 +1,10 @@
+package com.musinsam.eventservice.application.integration;
+
+import com.musinsam.eventservice.infrastructure.dto.res.ResProductInfoGetByProductId;
+import java.util.UUID;
+
+public interface ProductClient {
+
+  ResProductInfoGetByProductId getProductInfo(UUID productId);
+
+}

--- a/event-service/src/main/java/com/musinsam/eventservice/application/service/EventServiceImplApiV1.java
+++ b/event-service/src/main/java/com/musinsam/eventservice/application/service/EventServiceImplApiV1.java
@@ -15,6 +15,7 @@ import com.musinsam.eventservice.domain.event.repository.EventProductRepository;
 import com.musinsam.eventservice.domain.event.repository.EventRepository;
 import com.musinsam.eventservice.domain.event.vo.EventStatus;
 import com.musinsam.eventservice.infrastructure.dto.res.ResProductInfoGetByProductId;
+import feign.FeignException;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
@@ -52,8 +53,14 @@ public class EventServiceImplApiV1 implements EventServiceApiV1 {
       throw new RuntimeException("이미 등록된 상품입니다.");
     }
 
-    ResProductInfoGetByProductId productInfo = productClient.getProductInfo(
-        dto.getEventProduct().getProductId());
+    ResProductInfoGetByProductId productInfo;
+    try {
+      productInfo = productClient.getProductInfo(
+          dto.getEventProduct().getProductId());
+    } catch (FeignException e) {
+      throw new RuntimeException("상품을 등록할 수 없음돠 아마도 상품이 없음");
+    }
+
     String productName = productInfo.getProduct().getName();
 
     EventProductEntity eventProductEntity = dto.getEventProduct()

--- a/event-service/src/main/java/com/musinsam/eventservice/application/service/EventServiceImplApiV1.java
+++ b/event-service/src/main/java/com/musinsam/eventservice/application/service/EventServiceImplApiV1.java
@@ -8,11 +8,13 @@ import com.musinsam.eventservice.application.dto.request.ReqEventPutDtoApiV1;
 import com.musinsam.eventservice.application.dto.response.ResEventGetByEventIdDtoApiV1;
 import com.musinsam.eventservice.application.dto.response.ResEventGetDtoApiV1;
 import com.musinsam.eventservice.application.dto.response.ResEventGetProductByEventIdDtoApiV1;
+import com.musinsam.eventservice.application.integration.ProductClient;
 import com.musinsam.eventservice.domain.event.entity.EventEntity;
 import com.musinsam.eventservice.domain.event.entity.EventProductEntity;
 import com.musinsam.eventservice.domain.event.repository.EventProductRepository;
 import com.musinsam.eventservice.domain.event.repository.EventRepository;
 import com.musinsam.eventservice.domain.event.vo.EventStatus;
+import com.musinsam.eventservice.infrastructure.dto.res.ResProductInfoGetByProductId;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
@@ -29,6 +31,7 @@ public class EventServiceImplApiV1 implements EventServiceApiV1 {
 
   private final EventRepository eventRepository;
   private final EventProductRepository eventProductRepository;
+  private final ProductClient productClient;
 
   @Override
   @Transactional
@@ -44,10 +47,17 @@ public class EventServiceImplApiV1 implements EventServiceApiV1 {
 
     EventEntity eventEntity = findEventEntityById(eventId);
 
-    //TODO: Product와 통신하여 해당 상품이 있는지 확인 & 이름 가져오기?
+    if (eventProductRepository.existsByProductIdAndDeletedAtIsNull(
+        dto.getEventProduct().getProductId())) {
+      throw new RuntimeException("이미 등록된 상품입니다.");
+    }
 
-    EventProductEntity eventProductEntity = dto.getEventProduct().toEntity(eventEntity);
+    ResProductInfoGetByProductId productInfo = productClient.getProductInfo(
+        dto.getEventProduct().getProductId());
+    String productName = productInfo.getProduct().getName();
 
+    EventProductEntity eventProductEntity = dto.getEventProduct()
+        .toEntity(eventEntity, productName);
     eventProductRepository.save(eventProductEntity);
   }
 

--- a/event-service/src/main/java/com/musinsam/eventservice/domain/event/entity/EventProductEntity.java
+++ b/event-service/src/main/java/com/musinsam/eventservice/domain/event/entity/EventProductEntity.java
@@ -32,6 +32,9 @@ public class EventProductEntity extends BaseEntity {
   @Column(nullable = false)
   private UUID productId;
 
+  @Column(nullable = false)
+  private String productName;
+
   @Column
   @Setter
   private Integer discountRate;

--- a/event-service/src/main/java/com/musinsam/eventservice/domain/event/repository/EventProductRepository.java
+++ b/event-service/src/main/java/com/musinsam/eventservice/domain/event/repository/EventProductRepository.java
@@ -1,6 +1,7 @@
 package com.musinsam.eventservice.domain.event.repository;
 
 import com.musinsam.eventservice.domain.event.entity.EventProductEntity;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -17,4 +18,6 @@ public interface EventProductRepository {
 
   Optional<EventProductEntity> findByIdAndEventIdAndDeletedAtIsNull(UUID eventProductId,
       UUID eventId);
+
+  boolean existsByProductIdAndDeletedAtIsNull(@NotNull(message = "상품 ID를 입력해주세요.") UUID productId);
 }

--- a/event-service/src/main/java/com/musinsam/eventservice/infrastructure/client/ProductFeignClientApiV1.java
+++ b/event-service/src/main/java/com/musinsam/eventservice/infrastructure/client/ProductFeignClientApiV1.java
@@ -1,0 +1,17 @@
+package com.musinsam.eventservice.infrastructure.client;
+
+import com.musinsam.eventservice.application.integration.ProductClient;
+import com.musinsam.eventservice.infrastructure.dto.res.ResProductInfoGetByProductId;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "product-service")
+public interface ProductFeignClientApiV1 extends ProductClient {
+
+  // 상품 정보
+  @GetMapping("/internal/v1/products/{productId}")
+  ResProductInfoGetByProductId getProductInfo(@PathVariable UUID productId);
+
+}

--- a/event-service/src/main/java/com/musinsam/eventservice/infrastructure/dto/res/ResProductInfoGetByProductId.java
+++ b/event-service/src/main/java/com/musinsam/eventservice/infrastructure/dto/res/ResProductInfoGetByProductId.java
@@ -1,0 +1,26 @@
+package com.musinsam.eventservice.infrastructure.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResProductInfoGetByProductId {
+
+  private Product product;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Product {
+
+    private String name;
+
+  }
+
+}

--- a/product-service/src/main/java/com/musinsam/productservice/application/service/ProductServiceApiV1.java
+++ b/product-service/src/main/java/com/musinsam/productservice/application/service/ProductServiceApiV1.java
@@ -8,6 +8,7 @@ import com.musinsam.productservice.application.dto.response.ResProductGetByProdu
 import com.musinsam.productservice.application.dto.response.ResProductGetDtoApiV1;
 import com.musinsam.productservice.application.dto.response.ResProductGetStockDtoApiV1;
 import com.musinsam.productservice.domain.product.vo.ProductStatus;
+import com.musinsam.productservice.infrastructure.dto.res.ResProductInfoGetByProductId;
 import com.musinsam.productservice.infrastructure.s3.S3Folder;
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
@@ -50,4 +51,6 @@ public interface ProductServiceApiV1 {
   Boolean checkAndReduceStock(UUID productId, Integer quantity);
 
   void restoreStock(UUID productId, Integer quantity);
+
+  ResProductInfoGetByProductId getProductInfo(UUID productId);
 }

--- a/product-service/src/main/java/com/musinsam/productservice/application/service/ProductServiceImplApiV1.java
+++ b/product-service/src/main/java/com/musinsam/productservice/application/service/ProductServiceImplApiV1.java
@@ -18,6 +18,7 @@ import com.musinsam.productservice.domain.product.repository.ProductRepository;
 import com.musinsam.productservice.domain.product.repository.ProductRepositoryCustom;
 import com.musinsam.productservice.domain.product.vo.ProductStatus;
 import com.musinsam.productservice.global.exception.ProductErrorCode;
+import com.musinsam.productservice.infrastructure.dto.res.ResProductInfoGetByProductId;
 import com.musinsam.productservice.infrastructure.dto.res.ResShopCouponDtoApiV1;
 import com.musinsam.productservice.infrastructure.s3.S3Folder;
 import com.musinsam.productservice.infrastructure.s3.service.S3Service;
@@ -285,5 +286,14 @@ public class ProductServiceImplApiV1 implements ProductServiceApiV1 {
 
     productImageRepository.save(productImage);
 
+  }
+
+
+  @Override
+  public ResProductInfoGetByProductId getProductInfo(UUID productId) {
+
+    ProductEntity productEntity = findProductEntityById(productId);
+
+    return ResProductInfoGetByProductId.of(productEntity);
   }
 }

--- a/product-service/src/main/java/com/musinsam/productservice/infrastructure/dto/res/ResProductInfoGetByProductId.java
+++ b/product-service/src/main/java/com/musinsam/productservice/infrastructure/dto/res/ResProductInfoGetByProductId.java
@@ -1,0 +1,38 @@
+package com.musinsam.productservice.infrastructure.dto.res;
+
+import com.musinsam.productservice.domain.product.entity.ProductEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResProductInfoGetByProductId {
+
+  private Product product;
+
+  public static ResProductInfoGetByProductId of(ProductEntity productEntity) {
+    return ResProductInfoGetByProductId.builder()
+        .product(Product.from(productEntity))
+        .build();
+  }
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Product {
+
+    private String name;
+
+    public static Product from(ProductEntity productEntity) {
+      return Product.builder()
+          .name(productEntity.getName())
+          .build();
+    }
+  }
+
+}

--- a/product-service/src/main/java/com/musinsam/productservice/presentation/controller/ProductInternalControllerApiV1.java
+++ b/product-service/src/main/java/com/musinsam/productservice/presentation/controller/ProductInternalControllerApiV1.java
@@ -1,9 +1,12 @@
 package com.musinsam.productservice.presentation.controller;
 
 import com.musinsam.productservice.application.service.ProductServiceApiV1;
+import com.musinsam.productservice.infrastructure.dto.res.ResProductInfoGetByProductId;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -37,6 +40,16 @@ public class ProductInternalControllerApiV1 {
   ) {
     productService.restoreStock(productId, quantity);
     return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 상품 정보 - Event
+   */
+  @GetMapping("/{productId}")
+  public ResponseEntity<ResProductInfoGetByProductId> getProductInfo(
+      @PathVariable UUID productId
+  ) {
+    return ResponseEntity.ok().body(productService.getProductInfo(productId));
   }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #8 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 이벤트 상품에 상품명을 포함하여 저장 및 조회할 수 있도록 기능이 추가되었습니다.
    - 이벤트 서비스가 외부 상품 서비스와 연동되어 상품 정보를 실시간으로 조회합니다.
    - 상품 서비스에 상품 ID로 상품 정보를 반환하는 내부 API 엔드포인트가 추가되었습니다.

- **버그 수정**
    - 동일한(삭제되지 않은) 상품이 이벤트에 중복 등록되는 것을 방지합니다.

- **기타**
    - 서비스 간 통신을 위한 서비스 디스커버리 및 Feign 클라이언트가 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->